### PR TITLE
Adding static python environment

### DIFF
--- a/MapMerging/Dockerfile
+++ b/MapMerging/Dockerfile
@@ -1,0 +1,13 @@
+# Preparing the execution environment as a seperate build avoids re-building with code churn.
+# As long as requirements.txt remains static, the same environment can be re-used.
+
+FROM python:3.8-buster as base
+WORKDIR /mapmerging
+COPY requirements.txt .
+RUN apt-get update
+RUN apt-get install ffmpeg libsm6 libxext6  -y
+RUN pip3 install -r ./requirements.txt
+
+FROM base
+COPY . .
+ENTRYPOINT [ "python3", "hough_sift_mapmerge.py" ]

--- a/MapMerging/README.md
+++ b/MapMerging/README.md
@@ -10,3 +10,13 @@ Data contains the set of maps from UC Mercered dataset, see the readme contained
 
 Hough Line Detection Merge (Carpin et al. 2008)
 SIFT/ORB Keypoint-Based Homography Merge
+
+## Usage
+
+It's advised to build and test these experiments in a static environment.
+Therefore, we encourage execution within a contianer.
+
+```shell
+$ docker build . -t mapmerge-experiment
+$ docker run mapmerge-experiment
+```

--- a/MapMerging/requirements.txt
+++ b/MapMerging/requirements.txt
@@ -1,0 +1,7 @@
+numpy==1.21.4
+matplotlib==3.4.3
+numpy==1.21.4
+scipy==1.7.2
+scikit-image==0.18.3
+tqdm==4.62.3
+opencv-python==4.5.4.58


### PR DESCRIPTION
A static build/execution environment avoids all confusion of python versions and library compatibility. It's encouraged to develop in this same environment as well so all dependencies remain static.

Results from running `docker build -t mm . && docker run mm`
```
100%|██████████| 1000/1000 [29:15<00:00,  1.76s/it]
(Average Acc, Std Acc, Average Time) per map: (SIFT)
[0.99973504 0.99416408 0.99973265 0.99991089] [1.32522269e-03 1.00880303e-02 1.21334681e-03 6.58659414e-05] [-0.03710573 -0.21605085 -0.17291601 -0.55771276]
(Average Acc, Std Acc, Average Time) per map: (ORB)
[0.99319601 0.97481652 0.97927247 0.99912364] [0.01234019 0.0191485  0.03599063 0.00335668] [-0.01282909 -0.02888409 -0.02522461 -0.03358812]
(Average Acc, Std Acc, Average Time) per map: (HOUGH)
[0.94680059 0.88453682 0.84398215 0.82899945] [0.00768444 0.00152944 0.02702604 0.04226629] [-0.01824023 -0.06830395 -0.05683086 -0.09126971]
```

Let me know your thoughts.