### PR TITLE
Topic Namespacing

### DIFF
--- a/mdis_state_machine/include/robot_state_machine.h
+++ b/mdis_state_machine/include/robot_state_machine.h
@@ -138,7 +138,7 @@ private:
 class GoToExplore: public RobotState{
 public:
    GoToExplore(ros::NodeHandle &nh, bool testing):RobotState(GO_TO_EXPLORE, "GoToExplore", nh, testing){
-   robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>("/robots_state", 1000);     
+   robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>(nh.getNamespace() + "/robots_state", 1000);     
    }
    bool isDone() override ;
 
@@ -157,8 +157,8 @@ private:
 class Explore: public RobotState{
 public:
    Explore(ros::NodeHandle &nh, bool testing):RobotState(EXPLORE, "Explore", nh, testing){
-     pause_exploration_pub = nh.advertise<std_msgs::Bool>("explore/pause_exploration", 1000);     
-     robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>("/robots_state", 1000);     
+     pause_exploration_pub = nh.advertise<std_msgs::Bool>(nh.getNamespace() + "/explore/pause_exploration", 1000);     
+     robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>(nh.getNamespace() + "/robots_state", 1000);     
    }
    bool isDone() override ;
 
@@ -179,8 +179,8 @@ private:
 class GoToMeet: public RobotState{
 public:
    GoToMeet(ros::NodeHandle &nh, bool testing):RobotState(GO_TO_MEET, "GoToMeet", nh, testing){
-     conn_sub = nh.subscribe("/connection_check", 1000, &GoToMeet::connCB, this);     
-   robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>("/robots_state", 1000);     
+      conn_sub = nh.subscribe(nh.getNamespace() + "/connection_check", 1000, &GoToMeet::connCB, this);     
+      robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>(nh.getNamespace() + "/robots_state", 1000);
    }
    bool isDone() override ;
 
@@ -204,9 +204,9 @@ private:
 class Meet: public RobotState{
 public:
    Meet(ros::NodeHandle &nh, bool testing):RobotState(MEET, "Meet", nh, testing){
-     meeting_data_pub = nh.advertise<mdis_state_machine::DataCommunication>("/data_communication", 1000);
-     meeting_data_sub = nh.subscribe("/data_communication", 1000, &Meet::nextMeetingLocationCB, this);     
-     robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>("/robots_state", 1000);     
+     meeting_data_pub = nh.advertise<mdis_state_machine::DataCommunication>(nh.getNamespace() + "/data_communication", 1000);
+     meeting_data_sub = nh.subscribe(nh.getNamespace() + "/data_communication", 1000, &Meet::nextMeetingLocationCB, this);     
+     robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>(nh.getNamespace() + "/robots_state", 1000);     
    }
    bool isDone() override ;
 
@@ -235,7 +235,7 @@ private:
 class GoToDumpData: public RobotState{
 public:
    GoToDumpData(ros::NodeHandle &nh, bool testing):RobotState(GO_TO_DUMP_DATA, "GoToDumpData", nh, testing){
-   robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>("/robots_state", 1000);     
+   robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>(nh.getNamespace() + "/robots_state", 1000);     
    }
    bool isDone() override ;
 
@@ -254,7 +254,7 @@ private:
 class DumpData: public RobotState{
 public:
    DumpData(ros::NodeHandle &nh, bool testing):RobotState(DUMP_DATA, "DumpData", nh, testing){
-   robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>("/robots_state", 1000);     
+   robot_state_pub = nh.advertise<mdis_state_machine::RobotsState>(nh.getNamespace() + "/robots_state", 1000);     
    }
    bool isDone() override ;
 

--- a/mdis_state_machine/src/connection_check.cpp
+++ b/mdis_state_machine/src/connection_check.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
   }
   int number_of_robots = std::stoi(argv[1]);
   tf::TransformListener tf_listener;
-  ros::Publisher conn_pub = nh.advertise<mdis_state_machine::Connection>("connection_check", 1000);
+  ros::Publisher conn_pub = nh.advertise<mdis_state_machine::Connection>(nh.getNamespace() + "/connection_check", 1000);
 
   while(ros::ok())
   {


### PR DESCRIPTION
Each robot requires a unique namespace to pub/sub topics.
This requires nodes to be nested under a group.
Here's an example:
```xml
<launch>
  <group ns = "robot_1">
  
    <node pkg="mdis_state_machine" type="team_scheduler" name="team_scheduler" args="5 dummy_parent dummy_child" output="screen"/>
    
    <node name="coms_net_0" pkg="coms" type="net.py" output="screen">
        <param name="environment" value="sim" />
        <param name="ip" value="192.168.0.1" />
        <param name="launch" value="$(arg launch_file)"/>
        <param name="config" value="$(arg config_file)"/>
    </node>
    
    <node name='merge_handler' pkg='coms' type='merge_handler.py' output="screen">
        <param name="robot_name" value="$(arg robot_name)"/>
        <param name="map_service" value="$(arg map_service)"/>
    </node>

    <node name='gmapping_merger' pkg='coms' type='gmapping_merger.py' output="screen">
        <param name="robot_name" value="$(arg robot_name)"/>
        <param name="map_service" value="$(arg map_service)"/>
    </node>
    
  </group>
</launch>
```
This creates all nodes under the  `robot_1` namespace, creating the following topics:

- /robot_1/robots_state
- /robot_1/nearby
- /robot_1/connection_check
- /robot_1/data_communication
- /robot_1/explore/pause_exploration
